### PR TITLE
use correct counter of the for loop to check solutions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,23 @@
+@page RN11 Release notes for VIPR 1.1
+
+Features:
+-----------
+- handling of incomplete derivations (see Certificate Version 1.1)
+
+Build system
+------------
+
+Fixed bugs
+-----------
+- all constraints are now considered for checking the feasibility of solutions
+- improved error messages
+
+Data structures
+-----------
+
+
+@page RN10 Release notes for VIPR 1.0
+
+Features:
+-----------
+-  verify the correctness of results computed by mixed-integer linear programming solvers by verifying the certificates in VIPR 1.0 format

--- a/code/viprchk.cpp
+++ b/code/viprchk.cpp
@@ -760,9 +760,9 @@ bool processSOL()
 
             for( int j = 0; j < numberOfConstraints; ++j )
             {
-               if( !satisfies(constraint[i], solutionSpecified) )
+               if( !satisfies(constraint[j], solutionSpecified) )
                {
-                  cerr << "Constraint " << i << " not satisfied." << endl;
+                  cerr << "Constraint " << j << " not satisfied." << endl;
                   goto TERMINATE;
                }
             }


### PR DESCRIPTION
Instead of evaluating each constraint for each solution a fixed constraint was analyzed for m times because the counter in the for loop was not set correctly. 

Instead of accepting a wrong solution it now points out the violated constraints (GitHub does not like to have .vipr files uploaded.)

[bug.txt](https://github.com/user-attachments/files/17960139/bug.txt)


Is there a CHANGELOG to add bugfixes/improvements somewhere?
