### PR TITLE
add cons name to failing error message

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,9 +11,9 @@ Fixed bugs
 - allow comments at end of line in viprchk
 - allow empty and pure comment lines in viprcomp
 
-Data structures
+Miscellaneous
 -----------
-
+- print constraint name if constraint is not dominated during viprcomnp 
 
 @page RN11 Release notes for VIPR 1.1
 


### PR DESCRIPTION
If a constraint is not dominated the name is not printed. It would be helpful to have this name being able to track down the error easier. New output
``` 
Constraint ObjLimit830 does not dominate original one.
	Corrected Side is 17556157247397035275/2251799813685248 (7796.5)
	Original rhs is 274877906944 (274877906944)
```