### PR TITLE
align successful verifications logs

### DIFF
--- a/code/viprchk.cpp
+++ b/code/viprchk.cpp
@@ -1116,7 +1116,7 @@ bool processDER()
       {
          if( relationToProveType == RelationToProveType::INFEAS && constraint.back().isFalsehood() )
          {
-            cout << "Infeasibility verified." << endl;
+            cout << "Successfully verified infeasibility." << endl;
             return true;
          }
          else if( relationToProveType == RelationToProveType::RANGE && constraint.back().hasObjectiveCoefficients() && constraint.back().dominates(relationToProve) )

--- a/code/viprchk_parallel.cpp
+++ b/code/viprchk_parallel.cpp
@@ -1198,7 +1198,7 @@ bool parCheck_Der()
    {
       if( constraint.back().isFalsehood() )
       {
-         cout << "Infeasibility verified." << endl;
+         cout << "Successfully verified infeasibility." << endl;
          returnStatement = true;
       }
       else


### PR DESCRIPTION
With this change, it is sufficient to just run `grep -i "Successfully" DIRECTORY` to get all successful verified instances. 
Is this breaking something in the scip c-tests
